### PR TITLE
Add support for alternative rspec command

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -6,6 +6,26 @@ if !exists("g:rspec_runner")
   let g:rspec_runner = "os_x_terminal"
 endif
 
+function! RunCurrentSpecFileAsAlt()
+  let g:rspec_command = g:rspec_alternative_command
+  call RunCurrentSpecFile()
+endfunction
+
+function! RunNearestSpecAsAlt()
+  let g:rspec_command = g:rspec_alternative_command
+  call RunNearestSpec()
+endfunction
+
+function! RunLastSpecAsAlt()
+  let g:rspec_command = g:rspec_alternative_command
+  call RunLastSpec()
+endfunction
+
+function! RunAllSpecsAsAlt()
+  let g:rspec_command = g:rspec_alternative_command
+  call RunAllSpecs()
+endfunction
+
 function! RunAllSpecs()
   let s:last_spec = ""
   call s:RunSpecs(s:last_spec)


### PR DESCRIPTION
This commit adds support for an alternative rspec command.

The use case is when some work is running a vanilla local rails setup,
and some is using some other setup such as docker.

I found myself changing my rspec_command a lot between docker and
standard, so I updated the plugin to support an alternative command.

My vimrc now looks like this:

    let g:rspec_command = "!bundle exec rspec {spec}"
    let g:rspec_alternative_command = "!docker exec -i -t web bundle exec rspec {spec}"
    map <Leader>t :w<CR> :call RunCurrentSpecFile()<CR>
    map <Leader>s :w<CR> :call RunNearestSpec()<CR>
    map <Leader>l :w<CR> :call RunLastSpec()<CR>
    map <Leader>a :w<CR> :call RunAllSpecs()<CR>
    map <Leader>tx :w<CR> :call RunCurrentSpecFileAsAlt()<CR>
    map <Leader>sx :w<CR> :call RunNearestSpecAsAlt()<CR>
    map <Leader>lx :w<CR> :call RunLastSpecAsAlt()<CR>
    map <Leader>ax :w<CR> :call RunAllSpecsAsAlt()<CR>

I'm a relatively inexperienced developer, and this may not be anything
close to a sensible way of approaching this problem, but it saves me
time and I thought it might be interesting to others. At least an
interesting disucssion.